### PR TITLE
Fixed build with exiv2-0.27.1

### DIFF
--- a/exif-gps.cpp
+++ b/exif-gps.cpp
@@ -43,6 +43,7 @@
 
 #include "exiv2/image.hpp"
 #include "exiv2/exif.hpp"
+#include "exiv2/error.hpp"
 
 #include "gpsstructure.h"
 #include "exif-gps.h"


### PR DESCRIPTION
```bash
$ make CFLAGS=-DENABLE_NLS GTK=3
...
exif-gps.cpp: In function 'char* ReadExifDate(const char*, int*)':
exif-gps.cpp:103:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp: In function 'char* ReadExifData(const char*, double*, double*, double*, int*)':
exif-gps.cpp:160:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp: In function 'char* ReadGPSTimestamp(const char*, char*, char*, int*)':
exif-gps.cpp:298:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp: In function 'int WriteGPSData(const char*, const GPSPoint*, const char*, int, int)':
exif-gps.cpp:469:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp:619:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp: In function 'int WriteFixedDatestamp(const char*, time_t)':
exif-gps.cpp:649:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp:684:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp: In function 'int RemoveGPSExif(const char*, int, int)':
exif-gps.cpp:711:18: error: 'Error' in namespace 'Exiv2' does not name a type
  } catch (Exiv2::Error& e) {
                  ^~~~~
exif-gps.cpp:737:19: error: 'Error' in namespace 'Exiv2' does not name a type
   } catch (Exiv2::Error& e) {
                   ^~~~~
make: *** [Makefile:53: exif-gps.o] Error 1
```