### PR TITLE
Fix locale search path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ datadir  = $(prefix)/share
 mandir   = $(datadir)/man
 docdir   = $(datadir)/doc/gpscorrelate
 applicationsdir = $(datadir)/applications
+localedir = $(datadir)/locale
 
-DEFS = -DPACKAGE_VERSION=\"$(PACKAGE_VERSION)\"
+DEFS = -DPACKAGE_VERSION=\"$(PACKAGE_VERSION)\" -DPACKAGE_LOCALE_DIR=\"$(localedir)\"
 
 TARGETS = gpscorrelate-gui$(EXEEXT) gpscorrelate$(EXEEXT) doc/gpscorrelate.1 doc/gpscorrelate.html
 

--- a/main-command.c
+++ b/main-command.c
@@ -268,6 +268,7 @@ int main(int argc, char** argv)
 {
 	/* Initialize locale & gettext */
 	setlocale (LC_ALL, "");
+	(void) bindtextdomain(TEXTDOMAIN, PACKAGE_LOCALE_DIR);
 	(void) textdomain(TEXTDOMAIN);
 
 	/* If you didn't pass any arguments... */

--- a/main-gui.c
+++ b/main-gui.c
@@ -40,6 +40,7 @@
 int main(int argc, char* argv[])
 {
 	/* Initialize gettext (gtk_init initializes the locale) */
+	(void) bindtextdomain(TEXTDOMAIN, PACKAGE_LOCALE_DIR);
 	(void) textdomain(TEXTDOMAIN);
 	(void) bind_textdomain_codeset(TEXTDOMAIN, "UTF-8");
 


### PR DESCRIPTION
### Actual behaviour
```sh
$ make prefix=/path/to/install CFLAGS=-DENABLE_NLS
$ make prefix=/path/to/install install install-po install-desktop-file
$ LANG=ru_RU.UTF-8 strace -T -e trace=openat -- /path/to/install/bin/gpscorrelate-gui 2>&1 | egrep 'locale/ru/(.*)gpscorrelate'
openat(AT_FDCWD, "/usr/share/locale/ru/LC_MESSAGES/gpscorrelate.mo", O_RDONLY) = -1 ENOENT (No such file or directory) <0.000013>
```

### Expected behaviour
```sh
$ make prefix=/path/to/install CFLAGS=-DENABLE_NLS
$ make prefix=/path/to/install install install-po install-desktop-file
$ LANG=ru_RU.UTF-8 strace -T -e trace=openat -- /path/to/install/bin/gpscorrelate-gui 2>&1 | egrep 'locale/ru/(.*)gpscorrelate'
openat(AT_FDCWD, "/path/to/install/share/locale/ru/LC_MESSAGES/gpscorrelate.mo", O_RDONLY) = 3 <0.000029>
```

For more details, see [bindtextdomain](https://www.gnu.org/software/libc/manual/html_node/Locating-gettext-catalog.html#index-bindtextdomain).