### PR TITLE
Fix gpx-read.c: implicit declaration of function malloc

### DIFF
--- a/gpx-read.c
+++ b/gpx-read.c
@@ -26,6 +26,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <locale.h>
 #include <libxml/parser.h>


### PR DESCRIPTION
First observed in Gentoo Linux when using GCC 14. Most probably due to GCC 14 enabling -Wimplicit-function-declaration. Thus resulting in errors such as:

```
gpx-read.c: In function ExtractTrackPoints:
gpx-read.c:122:70: error: implicit declaration of function malloc [-Wimplicit-function-declaration]
  122 |                        LastPoint->Next = (struct GPSPoint*) malloc(sizeof(struct GPSPoint));
```

Bug: https://bugs.gentoo.org/923125